### PR TITLE
docs: update README to clarify permission requirements for GitHub Models inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ with:
   github_issue: ${{ github.event.pull_request.number }}
 ```
 
+The action requires the `models: read` permission to access GitHub Models inference and
+`pull-requests: write` permission to update the description of the pull request.
+
+```yaml
+permissions:
+  pull-requests: write
+  models: read
+```
+
 ## Example
 
 Save this code as `.github/workflows/genai-pull-request-descriptor.yml` in your repository:

--- a/genaisrc/pull-request-descriptor.genai.mts
+++ b/genaisrc/pull-request-descriptor.genai.mts
@@ -50,14 +50,8 @@ await g.exec(
 );
 
 const base = vars.base || (await g.defaultBranch());
-const branch = await g.branch();
-if (!branch) throw new Error("Unable to determine git current branch");
-
 console.debug(`base: ` + base);
-console.debug(`branch: ` + branch);
 dbg(`excluded: %s`, excluded);
-
-if (branch === base) cancel(`Already on the base branch '${base}'!`);
 
 // make sure the base branch is fetched
 await g.exec(["fetch", "origin", base]);


### PR DESCRIPTION


<!-- genaiscript begin pull-request-descriptor --><hr/>

- 📝 Updated README to clarify required GitHub Action permissions, specifying the need for `models: read` and `pull-requests: write` permissions, and provided a configuration example for `permissions`.
- 🔧 Simplified logic in the action’s script by removing checks and debug logs related to the current branch, thereby streamlining branch handling.

> AI-generated content by [pull-request-descriptor](https://github.com/pelikhan/action-genai-pull-request-descriptor/actions/runs/15671807419) may be incorrect. Use reactions to eval.



<!-- genaiscript end pull-request-descriptor -->

